### PR TITLE
Recommend pip first to install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,11 +2,10 @@
 Installation
 ============
 
-At the command line::
+At the command line, ideally in a virtualenv::
+
+    $ pip install django-random-filestorage
+
+Or if you don't have a virtualenv or pip but only setuptools::
 
     $ easy_install django-random-filestorage
-
-Or, if you have virtualenvwrapper installed::
-
-    $ mkvirtualenv django-random-filestorage
-    $ pip install django-random-filestorage


### PR DESCRIPTION
pip is endorsed by most Python people working on packaging standards and tools; easy_install is legacy.

I also removed the line creating a virtualenv named “django-random-filestorage”: people will work in a virtualenv created for their project, not one just for d-r-f, which is only one dependency out of many.
